### PR TITLE
Fix 1.16.x deployment api

### DIFF
--- a/charts/argo-tunnel/templates/deployment.yaml
+++ b/charts/argo-tunnel/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Throwing this error on helm install, k8s 1.16.x doesn't appear to support extensions/v1beta api version as there's now a stable version located at apps/v1
```
Error: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
```