### PR TITLE
Remove deprecated api version add apps/v1

### DIFF
--- a/charts/argo-tunnel/templates/deployment.yaml
+++ b/charts/argo-tunnel/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Thanks for this chart! I really love argo tunnel. It looks like `extensions/v1beta1` has been deprecated since kubernetes 1.9 and they recommend changing to the`apps/v1` api. In 1.16 that api version was [removed](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), so this chart no longer works. 