### PR TITLE
updated the deployment apiVersion

### DIFF
--- a/charts/argo-tunnel/Chart.yaml
+++ b/charts/argo-tunnel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: argo-tunnel
-version: 0.6.5
+version: 0.6.6
 home: https://developers.cloudflare.com/argo-tunnel/
 description: Installs the cloudflare argo tunnel ingress controller
 maintainers:

--- a/charts/argo-tunnel/templates/deployment.yaml
+++ b/charts/argo-tunnel/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
I updated this as 1.16 will not except extensions/v1beta1 anymore for deployments.