### PR TITLE
Allow using an externally provided secret for the tunnel credentials

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       volumes:
         - name: creds
           secret:
-            secretName: {{ include "cloudflare-tunnel.fullname" . }}
+            secretName: {{ .Values.cloudflare.secretName | default (include "cloudflare-tunnel.fullname" .) }}
         - name: config
           configMap:
             name: {{ include "cloudflare-tunnel.fullname" . }}

--- a/charts/cloudflare-tunnel/templates/secret.yaml
+++ b/charts/cloudflare-tunnel/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if and (and .Values.cloudflare.account .Values.cloudflare.tunnelId .Values.cloudflare.secret) (not .Values.cloudflare.secretName) }}
 # This credentials secret allows cloudflared to authenticate itself
 # to the Cloudflare infrastructure.
 apiVersion: v1
@@ -11,6 +12,6 @@ stringData:
     {
       "AccountTag": {{ .Values.cloudflare.account | quote }},
       "TunnelID": {{ .Values.cloudflare.tunnelId | quote }},
-      "TunnelName": {{ .Values.cloudflare.tunnelName | quote }},
       "TunnelSecret": {{ .Values.cloudflare.secret | quote }}
     }
+{{- end }}

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -10,6 +10,8 @@ cloudflare:
   tunnelId: ""
   # The secret for the tunnel.
   secret: ""
+  # If defined, no secret is created for the credentials, and instead, the secret referenced is used
+  secretName: null
   # If true, turn on WARP routing for TCP
   enableWarp: false
   # Define ingress rules for the tunnel. See


### PR DESCRIPTION
As raised also in https://github.com/cloudflare/helm-charts/issues/36, it would be nice to be able to use an externally provided secret instead of only passing the secrets as plain text in the `values.yaml`.

There are many ways to provision secrets into Kubernetes securely (Sealed Secrets, CSI Provisioners, ...), and to be able to use those in a flexible way, secrets should always offer the possibility to reference them and not generate them with the Helm chart itself.

@obezuk , pinging you as I have seen you are the only maintainer interacting in this repository lately.