### PR TITLE
fix(charts/cloudflare-tunnel-remote): remove invalid secret ref key

### DIFF
--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -23,21 +23,23 @@ spec:
     spec:
       serviceAccountName: {{ include "cloudflare-tunnel-remote.fullname" . }}
       containers:
-      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+      - name: cloudflared
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        name: cloudflared
         command:
           - cloudflared
           - tunnel
-          # In a k8s environment, the metrics server needs to listen outside the pod it runs on. 
+          # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
           # The address 0.0.0.0:2000 allows any pod in the namespace.
           - --metrics
           - 0.0.0.0:2000
           - run
-        envFrom:
-        - secretRef:
-            name: {{ include "cloudflare-tunnel-remote.fullname" . }}
-            key: TUNNEL_TOKEN
+        env:
+        - name: TUNNEL_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+              key: tunnelToken
         livenessProbe:
           httpGet:
             # Cloudflared has a /ready endpoint which returns 200 if and only if

--- a/charts/cloudflare-tunnel-remote/templates/secret.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/secret.yaml
@@ -7,4 +7,4 @@ metadata:
   labels:
     {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
 stringData:
-  TUNNEL_TOKEN: {{ .Values.cloudflare.tunnel_token }}
+  tunnelToken: {{ .Values.cloudflare.tunnel_token }}


### PR DESCRIPTION
It is not valid to specify individual keys with 'envFrom'. Instead, create environment variables for all secret key value pairs.

Fixes: #46