### PR TITLE
Disable auto-update

### DIFF
--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
           # The address 0.0.0.0:2000 allows any pod in the namespace.
           - --metrics
           - 0.0.0.0:2000
+          # Do not autoupdate as it will keep the pod in a crash loop due to the process being
+          # killed post-update
+          - --no-autoupdate
           - run
         envFrom:
         - secretRef:


### PR DESCRIPTION
Auto update causes the pod to die and get stuck in a crash loop.
We shouldn't auto update as the version of the container used is set by the chart values.