### PR TITLE
Add --no-autoupdate flag for cloudflare-tunnel-remote

### DIFF
--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - cloudflared
+          - --no-autoupdate
           - tunnel
           # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
           # The address 0.0.0.0:2000 allows any pod in the namespace.


### PR DESCRIPTION
It seems that the `cloudflare-tunnel-remote` helm chart is missing the `--no-autoupdate` flag which is added to the default [image in the entrypoint](https://hub.docker.com/layers/cloudflare/cloudflared/2023.8.2/images/sha256-680085f76a59c53b7827a170d43dbdc9ef87235af6c39c9d4d028fde38359233?context=explore) looking at the image layer:
```
ENTRYPOINT ["cloudflared" "--no-autoupdate"]
```

This results in `cloudflared` crashing everytime there is a new update. Looking at the logs of the pods stuck in crashbackloopoff:
```
2023-08-31T19:45:32Z INF cloudflared has been updated version=2023.8.2
2023-08-31T19:45:32Z INF Restarting service managed by SysV...
2023-08-31T19:45:32Z INF PID of the new process is 16
2023-08-31T19:45:32Z ERR Initiating shutdown error="cloudflared has been updated to version 2023.8.2"
```

It seems that it restarts itself once the update is finished, but since this is a pod, Kubernetes will restart it with the same configuration and `cloudflared` will be stuck in the same loop forever:
```bash
$ kubectl get pods -n cloudflared
NAME                                                   READY   STATUS    RESTARTS      AGE
cloudflared-cloudflare-tunnel-remote-dbcf68f9d-m77s6   1/1     Running   2 (23s ago)   2m
```

With this PR, the update will be shown in the logs as a warning and the pods will no longer be stuck in crashbackloopoff:
```
2023-08-31T19:53:08Z WRN Your version 2023.8.1 is outdated. We recommend upgrading it to 2023.8.2
```