### PR TITLE
Chart version updated -> 0.1.1

### DIFF
--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
         command:
           - cloudflared
           - tunnel
+          # We can regulate the cloudflared version via an image tag.
+          - --no-autoupdate
           # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
           # The address 0.0.0.0:2000 allows any pod in the namespace.
           - --metrics


### PR DESCRIPTION
As I can see from the fixes here: [GitHub Commit](https://github.com/cloudflare/helm-charts/commit/c53b4b314999baaab0402f39173bbc6e3b9d7b29), the chart version has not been updated :-(

Could you please increment the chart version and create new packages? Thank you!

Feel free to use this improved version :)