### PR TITLE
fix(cloudflare-tunnel-remote/charts): apply securityContext from values.yaml

### DIFF
--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -21,11 +21,13 @@ spec:
       labels:
         pod: cloudflared
     spec:
+      securityContext: {{ .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "cloudflare-tunnel-remote.fullname" . }}
       containers:
       - name: cloudflared
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext: {{ .Values.securityContext | nindent 10 }}
         command:
           - cloudflared
           - tunnel


### PR DESCRIPTION
What
---
The `charts/cloudflare-tunnel-remote` chart defines values for securityContext:   

https://github.com/cloudflare/helm-charts/blob/b85225eb49e1b0b40328c70d4541a27ec5e2b82e/charts/cloudflare-tunnel-remote/values.yaml#L35

and podSecurityContext:

https://github.com/cloudflare/helm-charts/blob/b85225eb49e1b0b40328c70d4541a27ec5e2b82e/charts/cloudflare-tunnel-remote/values.yaml#L30

but does not apply them to the pod template in deployment.

This simply maps the intended securityContext values into the appropriate locations on the template.

How to test
---
You can verify the template changes with by running `helm template .` inside the remote chart directory.

Evidence
---

``` yaml
 spec:
      serviceAccountName: release-name-cloudflare-tunnel
      securityContext:
        runAsNonRoot: true
        runAsUser: 65532
      containers:
        - name: cloudflare-tunnel
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
          image: "cloudflare/cloudflared:2023.5.1"
```