### PR TITLE
feat(cloudflare-tunnel-remote): add external secrets support

### DIFF
--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: TUNNEL_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+              name: {{ .Values.cloudflare.secretName | default (include "cloudflare-tunnel-remote.fullname" .) }}
               key: tunnelToken
         livenessProbe:
           httpGet:

--- a/charts/cloudflare-tunnel-remote/templates/secret.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/secret.yaml
@@ -1,5 +1,6 @@
 # This credentials secret allows cloudflared to authenticate itself
 # to the Cloudflare infrastructure.
+{{- if .Values.cloudflare.tunnel_token }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
     {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
 stringData:
   tunnelToken: {{ .Values.cloudflare.tunnel_token }}
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/values.yaml
+++ b/charts/cloudflare-tunnel-remote/values.yaml
@@ -3,6 +3,8 @@
 # Cloudflare parameters.
 cloudflare:
   tunnel_token: ""
+  # If defined, no secret is created for the credentials, and instead, the secret referenced is used
+  secretName: ""
 
 image:
   repository: cloudflare/cloudflared


### PR DESCRIPTION
PR https://github.com/cloudflare/helm-charts/pull/38 has introduced external secrets support for the main `cloudflare-tunnel` chart. 

As per the listed below links, the community does need this feature to be ported to `cloudflare-tunnel-remote` chart as well.

https://github.com/cloudflare/helm-charts/issues/36
https://github.com/cloudflare/helm-charts/issues/60
https://github.com/cloudflare/helm-charts/pull/63

This PR is a desperate attempt to push this forward by making minimal changes to ease the review by the maintainers.