### PR TITLE
fix(cloudflare-tunnel-remote): make indentation consistent

### DIFF
--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -23,31 +23,31 @@ spec:
     spec:
       serviceAccountName: {{ include "cloudflare-tunnel-remote.fullname" . }}
       containers:
-      - name: cloudflared
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-          - cloudflared
-          - tunnel
-          # We can regulate the cloudflared version via an image tag.
-          - --no-autoupdate
-          # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
-          # The address 0.0.0.0:2000 allows any pod in the namespace.
-          - --metrics
-          - 0.0.0.0:2000
-          - run
-        env:
-        - name: TUNNEL_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "cloudflare-tunnel-remote.fullname" . }}
-              key: tunnelToken
-        livenessProbe:
-          httpGet:
-            # Cloudflared has a /ready endpoint which returns 200 if and only if
-            # it has an active connection to the edge.
-            path: /ready
-            port: 2000
-          failureThreshold: 1
-          initialDelaySeconds: 10
-          periodSeconds: 10
+        - name: cloudflared
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - cloudflared
+            - tunnel
+            # We can regulate the cloudflared version via an image tag.
+            - --no-autoupdate
+            # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
+            # The address 0.0.0.0:2000 allows any pod in the namespace.
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+                  key: tunnelToken
+          livenessProbe:
+            httpGet:
+              # Cloudflared has a /ready endpoint which returns 200 if and only if
+              # it has an active connection to the edge.
+              path: /ready
+              port: 2000
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10


### PR DESCRIPTION
Indentation was inconsistent across different files for yaml lists

We have lint restrictions to require indents for yaml list items. This inconsistency creates problems for us.