### PR TITLE
remove: default 404 route

### DIFF
--- a/charts/cloudflare-tunnel/templates/configmap.yaml
+++ b/charts/cloudflare-tunnel/templates/configmap.yaml
@@ -25,5 +25,3 @@ data:
       {{- with .Values.cloudflare.ingress }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      # This rule matches any traffic which didn't match a previous rule, and responds with HTTP 404.
-      - service: http_status:404


### PR DESCRIPTION
Allow users to handle not found and wildcard domains using a custom backend.