### PR TITLE
Optional Daemonset deployment

### DIFF
--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -1,13 +1,19 @@
 # Here we deploy cloudflared images. The tunnel credentials are stored in
 # a k8s secret, and the configuration is stored in a k8s configmap.
 apiVersion: apps/v1
+{{- if .Values.daemonset -}}
+kind: Daemonset
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ include "cloudflare-tunnel.fullname" . }}
   labels:
     {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.daemonset -}}{{- else }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cloudflare-tunnel.selectorLabels" . | nindent 6 }}

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -34,6 +34,9 @@ image:
 
 replicaCount: 2
 
+# If true will run a daemonset, replicaCount is then ignored
+daemonset: false
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
I noticed it isn't currently possible to deploy this as a kube Daemonset.

The changes needed are quite small, and obviously we default to the current behaviour.

Using a replica count higher than the number of nodes seems counter productive based on documentation here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/deploy-tunnels/system-requirements/#recommendations

Multiple pods per node would then be fighting for the same ephemeral ports, so using a daemonset we can cap the cloudflared at 1 per node.