### PR TITLE
Add Pod Disruption Budget

### DIFF
--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel-remote/templates/pdb.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      pod: cloudflared
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/values.yaml
+++ b/charts/cloudflare-tunnel-remote/values.yaml
@@ -52,6 +52,14 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+podDisruptionBudget:
+  # PodDisruptionBudgets are essential to ensure that tunnels don't go down during normal cluster operations, like
+  # rolling restarts of nodes. If enabled will be added automatically once the replica size is greater than 1
+  # and ensure that at least one replica is ready before the pod will be drained.
+  enabled: false
+  minAvailable: 1
+  maxUnavailable:
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
👋 Hey there!

This adds a PodDisruptionBudget in a backwards compatible way, you can opt into it using `podDisruptionBudget.enabled=true`.

Important for cloudflare tunnels for the reasons listed in the comments in the [`values.yaml`](https://github.com/cloudflare/helm-charts/pull/89/files#diff-8d6c90d4eea88cd9dfb3c10d7550128f4e7a39c23864ae60727a52d274c688baR55) file
>   PodDisruptionBudgets are essential to ensure that tunnels don't go down during normal cluster operations, like rolling restarts of nodes. If enabled will be added automatically once the replica size is greater than 1 and ensure that at least one replica is ready before the pod will be drained.

Would be great to pair this with
- https://github.com/cloudflare/helm-charts/pull/65