### PR TITLE
feat: allow using existing secret for tunnel token

### DIFF
--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: TUNNEL_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+              name: {{ .Values.cloudflare.existingSecret | default (include "cloudflare-tunnel-remote.fullname" .) }}
               key: tunnelToken
         livenessProbe:
           httpGet:

--- a/charts/cloudflare-tunnel-remote/templates/secret.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.cloudflare.tunnel_token }}
 # This credentials secret allows cloudflared to authenticate itself
 # to the Cloudflare infrastructure.
 apiVersion: v1
@@ -7,4 +8,5 @@ metadata:
   labels:
     {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
 stringData:
-  tunnelToken: {{ .Values.cloudflare.tunnel_token }}
+  tunnelToken: {{ .Values.cloudflare.tunnel_token | quote }}
+  {{ end }}

--- a/charts/cloudflare-tunnel-remote/values.yaml
+++ b/charts/cloudflare-tunnel-remote/values.yaml
@@ -3,6 +3,7 @@
 # Cloudflare parameters.
 cloudflare:
   tunnel_token: ""
+  existingSecret: ""
 
 image:
   repository: cloudflare/cloudflared


### PR DESCRIPTION
- Adds `cloudflare.existingSecret` to values.yaml to allow users to bring their own Secret.
- Updates Deployment to use the existing secret name if provided.
- Conditionally creates the managed Secret only if `cloudflare.tunnel_token` is defined.
- Ensures the tunnel token is quoted in the generated Secret for YAML safety.
- Bumps chart version to 0.1.3.