### PR TITLE
Wire podSecurityContext and securityContext into deployment

### DIFF
--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -25,10 +25,18 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "cloudflare-tunnel-remote.fullname" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: cloudflared
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - cloudflared
           - tunnel


### PR DESCRIPTION
Both values are documented in values.yaml but were never rendered in the deployment template, leaving the chart's locked-down defaults (runAsNonRoot, dropped capabilities, read-only root filesystem) silently unused.